### PR TITLE
Add RepeatOrdinalWeek column to AreaRulePlanning

### DIFF
--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanning.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanning.cs
@@ -57,6 +57,14 @@ public class AreaRulePlanning: PnBase
     [StringLength(13)]
     public string? RepeatWeekdaysCsv { get; set; }
 
+    /// <summary>
+    /// Ordinal position within a month for "Nth weekday of month" monthly
+    /// rules (e.g. 3 = "3rd Tuesday of every month"). Used together with
+    /// DayOfWeek when RepeatType == Month. Null for legacy day-of-month
+    /// rules; valid values are 1..5.
+    /// </summary>
+    public int? RepeatOrdinalWeek { get; set; }
+
     public bool Status { get; set; }
 
     public bool SendNotifications { get; set; }

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanningVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanningVersion.cs
@@ -53,6 +53,8 @@ public class AreaRulePlanningVersion : PnBase
     [StringLength(13)]
     public string? RepeatWeekdaysCsv { get; set; }
 
+    public int? RepeatOrdinalWeek { get; set; }
+
     public bool Status { get; set; }
 
     public bool SendNotifications { get; set; }

--- a/Microting.EformBackendConfigurationBase/Migrations/20260527143323_AddRepeatOrdinalWeekToAreaRulePlanning.Designer.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260527143323_AddRepeatOrdinalWeekToAreaRulePlanning.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 namespace Microting.EformBackendConfigurationBase.Migrations
 {
     [DbContext(typeof(BackendConfigurationPnDbContext))]
-    partial class BackendConfigurationPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527143323_AddRepeatOrdinalWeekToAreaRulePlanning")]
+    partial class AddRepeatOrdinalWeekToAreaRulePlanning
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.EformBackendConfigurationBase/Migrations/20260527143323_AddRepeatOrdinalWeekToAreaRulePlanning.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260527143323_AddRepeatOrdinalWeekToAreaRulePlanning.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.EformBackendConfigurationBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepeatOrdinalWeekToAreaRulePlanning : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RepeatOrdinalWeek",
+                table: "AreaRulesPlanningVersions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RepeatOrdinalWeek",
+                table: "AreaRulePlannings",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RepeatOrdinalWeek",
+                table: "AreaRulesPlanningVersions");
+
+            migrationBuilder.DropColumn(
+                name: "RepeatOrdinalWeek",
+                table: "AreaRulePlannings");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new nullable int column \`RepeatOrdinalWeek\` to \`AreaRulePlanning\` and \`AreaRulePlanningVersion\` so the calendar can encode "Nth weekday of every month" rules (e.g. \`3\` = 3rd Tuesday of every month).

## Encoding
- Used together with the existing \`DayOfWeek\` column when \`RepeatType == Month\`
- Valid values: \`1\`..\`5\` (1st through 5th occurrence)
- Legacy day-of-month rules (\`DayOfMonth\` set, \`RepeatOrdinalWeek\` null) are unaffected

## Files
- \`AreaRulePlanning.cs\` — new property + XML doc
- \`AreaRulePlanningVersion.cs\` — mirror property
- \`Migrations/20260527143323_AddRepeatOrdinalWeekToAreaRulePlanning\` — EF migration generated via \`dotnet ef migrations add\`
- \`BackendConfigurationPnDbContextModelSnapshot.cs\` — snapshot update

## Follow-up
After this merges, tag \`v10.0.37\` to publish the new NuGet, then the plugin PR (\`eform-backendconfiguration-plugin\`) consumes it to wire up the iterator and proto.

Generated with [Claude Code](https://claude.com/claude-code)