### PR TITLE
Add per-occurrence field-override columns to CalendarOccurrenceException (#885)

### DIFF
--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/CalendarOccurrenceException.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/CalendarOccurrenceException.cs
@@ -12,5 +12,16 @@ public class CalendarOccurrenceException : PnBase
     public DateTime? NewDate { get; set; }
     public double? StartHour { get; set; }
     public double? Duration { get; set; }
+
+    // Per-occurrence field overrides for scope="this" edits (issue #885).
+    // Null means "inherit the series value" when rendering the occurrence;
+    // a non-null value overrides just this occurrence. eForm, tags, status,
+    // compliance and repeat stay series-level only and are intentionally not
+    // overridable per occurrence.
+    public string Title { get; set; }
+    public string DescriptionHtml { get; set; }
+    public int? BoardId { get; set; }
+    public string Color { get; set; }
+
     public virtual List<CalendarOccurrenceExceptionSite> ExceptionSites { get; set; } = [];
 }

--- a/Microting.EformBackendConfigurationBase/Migrations/20260602051137_AddCalendarOccurrenceExceptionFieldOverrides.Designer.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260602051137_AddCalendarOccurrenceExceptionFieldOverrides.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 namespace Microting.EformBackendConfigurationBase.Migrations
 {
     [DbContext(typeof(BackendConfigurationPnDbContext))]
-    partial class BackendConfigurationPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602051137_AddCalendarOccurrenceExceptionFieldOverrides")]
+    partial class AddCalendarOccurrenceExceptionFieldOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.EformBackendConfigurationBase/Migrations/20260602051137_AddCalendarOccurrenceExceptionFieldOverrides.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260602051137_AddCalendarOccurrenceExceptionFieldOverrides.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.EformBackendConfigurationBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCalendarOccurrenceExceptionFieldOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BoardId",
+                table: "CalendarOccurrenceExceptions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Color",
+                table: "CalendarOccurrenceExceptions",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DescriptionHtml",
+                table: "CalendarOccurrenceExceptions",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Title",
+                table: "CalendarOccurrenceExceptions",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BoardId",
+                table: "CalendarOccurrenceExceptions");
+
+            migrationBuilder.DropColumn(
+                name: "Color",
+                table: "CalendarOccurrenceExceptions");
+
+            migrationBuilder.DropColumn(
+                name: "DescriptionHtml",
+                table: "CalendarOccurrenceExceptions");
+
+            migrationBuilder.DropColumn(
+                name: "Title",
+                table: "CalendarOccurrenceExceptions");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Groundwork in the base layer for fixing scope-aware calendar edits (microting/eform-backendconfiguration-plugin#885).

Adds four **nullable** columns to `CalendarOccurrenceException` so a `scope="this"` edit can override a single occurrence instead of relocating the whole recurring series' `StartDate`:

- `Title`
- `DescriptionHtml`
- `BoardId`
- `Color`

Timing (`StartHour`/`Duration`/`NewDate`) and assignees (`ExceptionSites`) were already overridable. **eForm, tags, status, compliance and repeat remain series-level only by design** (they touch compliance-case deployment / reporting and are out of scope for this increment).

## Changes
- `CalendarOccurrenceException` entity: 4 nullable properties (null = inherit series value).
- EF migration `AddCalendarOccurrenceExceptionFieldOverrides` (generated via `dotnet ef migrations add`, includes Designer + snapshot). Additive, nullable-only → backward compatible.

## Follow-up
The plugin-side `UpdateTask` scope branching + `GetTasksForWeek` overlay rendering land in the plugin repo once this base version is published and referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)