### PR TITLE
feat: AreaRuleTranslation.Description column (calendar multi-language descriptions)

### DIFF
--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRuleTranslation.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRuleTranslation.cs
@@ -32,6 +32,8 @@ public class AreaRuleTranslation : PnBase
     [StringLength(250)]
     public string Name { get; set; }
 
+    public string Description { get; set; }
+
     public int LanguageId { get; set; }
 
     public int AreaRuleId { get; set; }

--- a/Microting.EformBackendConfigurationBase/Migrations/20260608034728_AddDescriptionToAreaRuleTranslation.Designer.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260608034728_AddDescriptionToAreaRuleTranslation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 namespace Microting.EformBackendConfigurationBase.Migrations
 {
     [DbContext(typeof(BackendConfigurationPnDbContext))]
-    partial class BackendConfigurationPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608034728_AddDescriptionToAreaRuleTranslation")]
+    partial class AddDescriptionToAreaRuleTranslation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.EformBackendConfigurationBase/Migrations/20260608034728_AddDescriptionToAreaRuleTranslation.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260608034728_AddDescriptionToAreaRuleTranslation.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.EformBackendConfigurationBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDescriptionToAreaRuleTranslation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "AreaRuleTranslations",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "AreaRuleTranslations");
+        }
+    }
+}


### PR DESCRIPTION
Adds a nullable per-language `Description` column to `AreaRuleTranslation` so calendar task **descriptions** can be stored per language (titles already persist per-language via `AreaRuleTranslation.Name`).

Greenfield — no data backfill: there is no existing per-language description data to migrate.

Migration: `AddDescriptionToAreaRuleTranslation` (generated via `dotnet ef`). Part of the calendar task multi-language Title & Description feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)