### PR TITLE
Add AreaRulePlanningWorkerTag entity (calendar event ↔ worker tag)

### DIFF
--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
@@ -127,6 +127,9 @@ public class BackendConfigurationPnDbContext: DbContext, IPluginDbContext
     public DbSet<AreaRulePlanningTag> AreaRulePlanningTags { get; set; }
     public DbSet<AreaRulePlanningTagVersion> AreaRulePlanningTagVersion { get; set; }
 
+    public DbSet<AreaRulePlanningWorkerTag> AreaRulePlanningWorkerTags { get; set; }
+    public DbSet<AreaRulePlanningWorkerTagVersion> AreaRulePlanningWorkerTagVersion { get; set; }
+
     public DbSet<AreaRulePlanningFile> AreaRulePlanningFiles { get; set; }
     public DbSet<AreaRulePlanningFileVersion> AreaRulePlanningFileVersions { get; set; }
 
@@ -218,6 +221,11 @@ public class BackendConfigurationPnDbContext: DbContext, IPluginDbContext
 
         modelBuilder.Entity<AreaRulePlanningTag>().HasOne(x => x.AreaRulePlanning)
             .WithMany(x => x.AreaRulePlanningTags)
+            .HasForeignKey(x => x.AreaRulePlanningId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<AreaRulePlanningWorkerTag>().HasOne(x => x.AreaRulePlanning)
+            .WithMany(x => x.AreaRulePlanningWorkerTags)
             .HasForeignKey(x => x.AreaRulePlanningId)
             .OnDelete(DeleteBehavior.Restrict);
 

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanning.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanning.cs
@@ -100,6 +100,8 @@ public class AreaRulePlanning: PnBase
 
     public virtual List<AreaRulePlanningTag> AreaRulePlanningTags { get; set; } = new();
 
+    public virtual List<AreaRulePlanningWorkerTag> AreaRulePlanningWorkerTags { get; set; } = new();
+
     public virtual ICollection<AreaRulePlanningFile> AreaRulePlanningFiles { get; set; }
         = new List<AreaRulePlanningFile>();
 }

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanningWorkerTag.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanningWorkerTag.cs
@@ -1,0 +1,11 @@
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AreaRulePlanningWorkerTag : PnBase
+{
+    public int AreaRulePlanningId { get; set; }
+
+    public virtual AreaRulePlanning AreaRulePlanning { get; set; }
+
+    // References SDK Tag.Id (different DB — no nav prop, same pattern as PlanningSite.SiteId)
+    public int TagId { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanningWorkerTagVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AreaRulePlanningWorkerTagVersion.cs
@@ -1,0 +1,10 @@
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AreaRulePlanningWorkerTagVersion : PnBase
+{
+    public int AreaRulePlanningWorkerTagId { get; set; }
+
+    public int AreaRulePlanningId { get; set; }
+
+    public int TagId { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Migrations/20260612134557_AddAreaRulePlanningWorkerTag.Designer.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260612134557_AddAreaRulePlanningWorkerTag.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 namespace Microting.EformBackendConfigurationBase.Migrations
 {
     [DbContext(typeof(BackendConfigurationPnDbContext))]
-    partial class BackendConfigurationPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260612134557_AddAreaRulePlanningWorkerTag")]
+    partial class AddAreaRulePlanningWorkerTag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.EformBackendConfigurationBase/Migrations/20260612134557_AddAreaRulePlanningWorkerTag.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260612134557_AddAreaRulePlanningWorkerTag.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.EformBackendConfigurationBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAreaRulePlanningWorkerTag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AreaRulePlanningWorkerTags",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AreaRulePlanningId = table.Column<int>(type: "int", nullable: false),
+                    TagId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AreaRulePlanningWorkerTags", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AreaRulePlanningWorkerTags_AreaRulePlannings_AreaRulePlannin~",
+                        column: x => x.AreaRulePlanningId,
+                        principalTable: "AreaRulePlannings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AreaRulePlanningWorkerTagVersion",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AreaRulePlanningWorkerTagId = table.Column<int>(type: "int", nullable: false),
+                    AreaRulePlanningId = table.Column<int>(type: "int", nullable: false),
+                    TagId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AreaRulePlanningWorkerTagVersion", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AreaRulePlanningWorkerTags_AreaRulePlanningId",
+                table: "AreaRulePlanningWorkerTags",
+                column: "AreaRulePlanningId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AreaRulePlanningWorkerTags");
+
+            migrationBuilder.DropTable(
+                name: "AreaRulePlanningWorkerTagVersion");
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a new versioned EF Core join entity **`AreaRulePlanningWorkerTag`** (+ `AreaRulePlanningWorkerTagVersion`) linking a calendar event (`AreaRulePlanning`) to a worker tag (SDK `Tag.Id`, a bare int — different DB, same pattern as `PlanningSite.SiteId`).

- New entities follow the existing `AreaRulePlanningTag` / `AreaRulePlanningTagVersion` convention exactly.
- DbContext: two `DbSet`s + fluent FK config (`HasOne`/`WithMany`/`OnDelete(Restrict)`).
- `AreaRulePlanning` gains an `AreaRulePlanningWorkerTags` nav collection.
- EF-generated migration `20260612134557_AddAreaRulePlanningWorkerTag` (both tables, FK + index, snapshot updated).

## Why

Foundation for assigning calendar events to **worker tags** (dynamic, retroactive recipient resolution). See design spec `2026-06-12-calendar-assign-events-to-worker-tags-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)