### PR TITLE
Add Adhoc task entities and AddAdhocTasks migration (flutter-adhoc M3)

### DIFF
--- a/Microting.EformBackendConfigurationBase.Tests/AdhocAreaUTest.cs
+++ b/Microting.EformBackendConfigurationBase.Tests/AdhocAreaUTest.cs
@@ -1,0 +1,179 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using eForm.Infrastructure.Constants;
+using Infrastructure.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+[TestFixture]
+public class AdhocAreaUTest : DbTestFixture
+{
+    private static string GetRandomStr() => Guid.NewGuid().ToString();
+
+    private async Task<Property> CreateProperty()
+    {
+        var property = new Property
+        {
+            Address = GetRandomStr(),
+            CHR = GetRandomStr(),
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await property.Create(DbContext);
+
+        return property;
+    }
+
+    [Test]
+    public async Task AdhocArea_Create_DoesSave()
+    {
+        // Arrange
+        var property = await CreateProperty();
+
+        var adhocArea = new AdhocArea
+        {
+            PropertyId = property.Id,
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        // Act
+        await adhocArea.Create(DbContext);
+
+        var adhocAreaList = DbContext.AdhocAreas.AsNoTracking().ToList();
+        var adhocAreaVersionList = DbContext.AdhocAreaVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(adhocAreaList.Count, Is.EqualTo(1));
+        Assert.That(adhocAreaVersionList.Count, Is.EqualTo(1));
+        Assert.That(adhocAreaList[0].PropertyId, Is.EqualTo(property.Id));
+        Assert.That(adhocAreaList[0].Name, Is.EqualTo(adhocArea.Name));
+        Assert.That(adhocAreaList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocAreaList[0].Version, Is.EqualTo(1));
+
+        Assert.That(adhocAreaVersionList[0].AdhocAreaId, Is.EqualTo(adhocArea.Id));
+        Assert.That(adhocAreaVersionList[0].PropertyId, Is.EqualTo(property.Id));
+        Assert.That(adhocAreaVersionList[0].Name, Is.EqualTo(adhocArea.Name));
+        Assert.That(adhocAreaVersionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocAreaVersionList[0].Version, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task AdhocArea_Update_DoesUpdate()
+    {
+        // Arrange
+        var propertyOne = await CreateProperty();
+        var propertyTwo = await CreateProperty();
+
+        var adhocArea = new AdhocArea
+        {
+            PropertyId = propertyOne.Id,
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await adhocArea.Create(DbContext);
+        var adhocAreaOld = DbContext.AdhocAreas.AsNoTracking().First();
+
+        // Act
+        adhocArea.PropertyId = propertyTwo.Id;
+        adhocArea.Name = GetRandomStr();
+        adhocArea.UpdatedByUserId = 2;
+
+        await adhocArea.Update(DbContext);
+
+        var adhocAreaList = DbContext.AdhocAreas.AsNoTracking().ToList();
+        var adhocAreaVersionList = DbContext.AdhocAreaVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(adhocAreaList.Count, Is.EqualTo(1));
+        Assert.That(adhocAreaVersionList.Count, Is.EqualTo(2));
+        Assert.That(adhocAreaList[0].PropertyId, Is.EqualTo(propertyTwo.Id));
+        Assert.That(adhocAreaList[0].Name, Is.EqualTo(adhocArea.Name));
+        Assert.That(adhocAreaList[0].UpdatedByUserId, Is.EqualTo(2));
+        Assert.That(adhocAreaList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocAreaList[0].Id, Is.EqualTo(adhocArea.Id));
+        Assert.That(adhocAreaList[0].Version, Is.EqualTo(2));
+
+        Assert.That(adhocAreaVersionList[0].AdhocAreaId, Is.EqualTo(adhocArea.Id));
+        Assert.That(adhocAreaVersionList[0].PropertyId, Is.EqualTo(adhocAreaOld.PropertyId));
+        Assert.That(adhocAreaVersionList[0].Name, Is.EqualTo(adhocAreaOld.Name));
+        Assert.That(adhocAreaVersionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocAreaVersionList[0].Version, Is.EqualTo(1));
+
+        Assert.That(adhocAreaVersionList[1].AdhocAreaId, Is.EqualTo(adhocArea.Id));
+        Assert.That(adhocAreaVersionList[1].PropertyId, Is.EqualTo(propertyTwo.Id));
+        Assert.That(adhocAreaVersionList[1].Name, Is.EqualTo(adhocArea.Name));
+        Assert.That(adhocAreaVersionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocAreaVersionList[1].Version, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task AdhocArea_Delete_DoesDelete()
+    {
+        // Arrange
+        var property = await CreateProperty();
+
+        var adhocArea = new AdhocArea
+        {
+            PropertyId = property.Id,
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await adhocArea.Create(DbContext);
+
+        // Act
+        await adhocArea.Delete(DbContext);
+
+        var adhocAreaList = DbContext.AdhocAreas.AsNoTracking().ToList();
+        var adhocAreaVersionList = DbContext.AdhocAreaVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(adhocAreaList.Count, Is.EqualTo(1));
+        Assert.That(adhocAreaVersionList.Count, Is.EqualTo(2));
+        Assert.That(adhocAreaList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(adhocAreaList[0].Id, Is.EqualTo(adhocArea.Id));
+        Assert.That(adhocAreaList[0].Version, Is.EqualTo(2));
+
+        Assert.That(adhocAreaVersionList[0].AdhocAreaId, Is.EqualTo(adhocArea.Id));
+        Assert.That(adhocAreaVersionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocAreaVersionList[0].Version, Is.EqualTo(1));
+
+        Assert.That(adhocAreaVersionList[1].AdhocAreaId, Is.EqualTo(adhocArea.Id));
+        Assert.That(adhocAreaVersionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(adhocAreaVersionList[1].Version, Is.EqualTo(2));
+    }
+}

--- a/Microting.EformBackendConfigurationBase.Tests/AdhocTagUTest.cs
+++ b/Microting.EformBackendConfigurationBase.Tests/AdhocTagUTest.cs
@@ -1,0 +1,179 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using eForm.Infrastructure.Constants;
+using Infrastructure.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+[TestFixture]
+public class AdhocTagUTest : DbTestFixture
+{
+    private static string GetRandomStr() => Guid.NewGuid().ToString();
+
+    [Test]
+    public async Task AdhocTag_Create_DoesSave_GlobalTag()
+    {
+        // Arrange
+        var adhocTag = new AdhocTag
+        {
+            Name = GetRandomStr(),
+            OwnerWorkerId = null,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        // Act
+        await adhocTag.Create(DbContext);
+
+        var adhocTagList = DbContext.AdhocTags.AsNoTracking().ToList();
+        var adhocTagVersionList = DbContext.AdhocTagVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(adhocTagList.Count, Is.EqualTo(1));
+        Assert.That(adhocTagVersionList.Count, Is.EqualTo(1));
+        Assert.That(adhocTagList[0].Name, Is.EqualTo(adhocTag.Name));
+        Assert.That(adhocTagList[0].OwnerWorkerId, Is.Null);
+        Assert.That(adhocTagList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocTagList[0].Version, Is.EqualTo(1));
+
+        Assert.That(adhocTagVersionList[0].AdhocTagId, Is.EqualTo(adhocTag.Id));
+        Assert.That(adhocTagVersionList[0].Name, Is.EqualTo(adhocTag.Name));
+        Assert.That(adhocTagVersionList[0].OwnerWorkerId, Is.Null);
+        Assert.That(adhocTagVersionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocTagVersionList[0].Version, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task AdhocTag_Create_DoesSave_UserOwnedTag()
+    {
+        // Arrange
+        var adhocTag = new AdhocTag
+        {
+            Name = GetRandomStr(),
+            OwnerWorkerId = 42,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        // Act
+        await adhocTag.Create(DbContext);
+
+        var adhocTagList = DbContext.AdhocTags.AsNoTracking().ToList();
+        var adhocTagVersionList = DbContext.AdhocTagVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(adhocTagList[0].OwnerWorkerId, Is.EqualTo(42));
+        Assert.That(adhocTagVersionList[0].OwnerWorkerId, Is.EqualTo(42));
+    }
+
+    [Test]
+    public async Task AdhocTag_Update_DoesUpdate()
+    {
+        // Arrange
+        var adhocTag = new AdhocTag
+        {
+            Name = GetRandomStr(),
+            OwnerWorkerId = 42,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await adhocTag.Create(DbContext);
+        var adhocTagOld = DbContext.AdhocTags.AsNoTracking().First();
+
+        // Act
+        adhocTag.Name = GetRandomStr();
+        adhocTag.OwnerWorkerId = null;
+        adhocTag.UpdatedByUserId = 2;
+
+        await adhocTag.Update(DbContext);
+
+        var adhocTagList = DbContext.AdhocTags.AsNoTracking().ToList();
+        var adhocTagVersionList = DbContext.AdhocTagVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(adhocTagList.Count, Is.EqualTo(1));
+        Assert.That(adhocTagVersionList.Count, Is.EqualTo(2));
+        Assert.That(adhocTagList[0].Name, Is.EqualTo(adhocTag.Name));
+        Assert.That(adhocTagList[0].OwnerWorkerId, Is.Null);
+        Assert.That(adhocTagList[0].UpdatedByUserId, Is.EqualTo(2));
+        Assert.That(adhocTagList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocTagList[0].Id, Is.EqualTo(adhocTag.Id));
+        Assert.That(adhocTagList[0].Version, Is.EqualTo(2));
+
+        Assert.That(adhocTagVersionList[0].AdhocTagId, Is.EqualTo(adhocTag.Id));
+        Assert.That(adhocTagVersionList[0].Name, Is.EqualTo(adhocTagOld.Name));
+        Assert.That(adhocTagVersionList[0].OwnerWorkerId, Is.EqualTo(42));
+        Assert.That(adhocTagVersionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocTagVersionList[0].Version, Is.EqualTo(1));
+
+        Assert.That(adhocTagVersionList[1].AdhocTagId, Is.EqualTo(adhocTag.Id));
+        Assert.That(adhocTagVersionList[1].Name, Is.EqualTo(adhocTag.Name));
+        Assert.That(adhocTagVersionList[1].OwnerWorkerId, Is.Null);
+        Assert.That(adhocTagVersionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocTagVersionList[1].Version, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task AdhocTag_Delete_DoesDelete()
+    {
+        // Arrange
+        var adhocTag = new AdhocTag
+        {
+            Name = GetRandomStr(),
+            OwnerWorkerId = 7,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await adhocTag.Create(DbContext);
+
+        // Act
+        await adhocTag.Delete(DbContext);
+
+        var adhocTagList = DbContext.AdhocTags.AsNoTracking().ToList();
+        var adhocTagVersionList = DbContext.AdhocTagVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(adhocTagList.Count, Is.EqualTo(1));
+        Assert.That(adhocTagVersionList.Count, Is.EqualTo(2));
+        Assert.That(adhocTagList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(adhocTagList[0].Id, Is.EqualTo(adhocTag.Id));
+        Assert.That(adhocTagList[0].Version, Is.EqualTo(2));
+
+        Assert.That(adhocTagVersionList[0].AdhocTagId, Is.EqualTo(adhocTag.Id));
+        Assert.That(adhocTagVersionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(adhocTagVersionList[0].Version, Is.EqualTo(1));
+
+        Assert.That(adhocTagVersionList[1].AdhocTagId, Is.EqualTo(adhocTag.Id));
+        Assert.That(adhocTagVersionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(adhocTagVersionList[1].Version, Is.EqualTo(2));
+    }
+}

--- a/Microting.EformBackendConfigurationBase.Tests/AdhocTaskChildrenUTest.cs
+++ b/Microting.EformBackendConfigurationBase.Tests/AdhocTaskChildrenUTest.cs
@@ -1,0 +1,547 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using eForm.Infrastructure.Constants;
+using Infrastructure.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+[TestFixture]
+public class AdhocTaskChildrenUTest : DbTestFixture
+{
+    private static string GetRandomStr() => Guid.NewGuid().ToString();
+
+    private async Task<AdhocTaskEntity> CreateAdhocTask()
+    {
+        var property = new Property
+        {
+            Address = GetRandomStr(),
+            CHR = GetRandomStr(),
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await property.Create(DbContext);
+
+        var adhocTaskEntity = new AdhocTaskEntity
+        {
+            Title = GetRandomStr(),
+            Description = GetRandomStr(),
+            PropertyId = property.Id,
+            CreatedByWorkerId = 1,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await adhocTaskEntity.Create(DbContext);
+
+        return adhocTaskEntity;
+    }
+
+    private async Task<AdhocTag> CreateAdhocTag()
+    {
+        var adhocTag = new AdhocTag
+        {
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await adhocTag.Create(DbContext);
+
+        return adhocTag;
+    }
+
+    #region AdhocTaskAssignment
+
+    [Test]
+    public async Task AdhocTaskAssignment_Create_DoesSave()
+    {
+        var task = await CreateAdhocTask();
+
+        var assignment = new AdhocTaskAssignment
+        {
+            AdhocTaskId = task.Id,
+            WorkerId = 42,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await assignment.Create(DbContext);
+
+        var list = DbContext.AdhocTaskAssignments.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskAssignmentVersions.AsNoTracking().ToList();
+
+        Assert.That(list.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(1));
+        Assert.That(list[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(list[0].WorkerId, Is.EqualTo(42));
+        Assert.That(list[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(list[0].Version, Is.EqualTo(1));
+
+        Assert.That(versionList[0].AdhocTaskAssignmentId, Is.EqualTo(assignment.Id));
+        Assert.That(versionList[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(versionList[0].WorkerId, Is.EqualTo(42));
+        Assert.That(versionList[0].Version, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task AdhocTaskAssignment_Update_DoesUpdate()
+    {
+        var taskOne = await CreateAdhocTask();
+        var taskTwo = await CreateAdhocTask();
+
+        var assignment = new AdhocTaskAssignment
+        {
+            AdhocTaskId = taskOne.Id,
+            WorkerId = 1,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await assignment.Create(DbContext);
+        var old = DbContext.AdhocTaskAssignments.AsNoTracking().First();
+
+        assignment.AdhocTaskId = taskTwo.Id;
+        assignment.WorkerId = 2;
+        assignment.UpdatedByUserId = 2;
+        await assignment.Update(DbContext);
+
+        var list = DbContext.AdhocTaskAssignments.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskAssignmentVersions.AsNoTracking().ToList();
+
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(list[0].AdhocTaskId, Is.EqualTo(taskTwo.Id));
+        Assert.That(list[0].WorkerId, Is.EqualTo(2));
+        Assert.That(list[0].Version, Is.EqualTo(2));
+
+        Assert.That(versionList[0].AdhocTaskId, Is.EqualTo(old.AdhocTaskId));
+        Assert.That(versionList[0].WorkerId, Is.EqualTo(old.WorkerId));
+        Assert.That(versionList[1].AdhocTaskId, Is.EqualTo(taskTwo.Id));
+        Assert.That(versionList[1].WorkerId, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task AdhocTaskAssignment_Delete_DoesDelete()
+    {
+        var task = await CreateAdhocTask();
+
+        var assignment = new AdhocTaskAssignment
+        {
+            AdhocTaskId = task.Id,
+            WorkerId = 7,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await assignment.Create(DbContext);
+
+        await assignment.Delete(DbContext);
+
+        var list = DbContext.AdhocTaskAssignments.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskAssignmentVersions.AsNoTracking().ToList();
+
+        Assert.That(list[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(list[0].Version, Is.EqualTo(2));
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(versionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
+    #endregion
+
+    #region AdhocTaskAssignmentLog
+
+    [Test]
+    public async Task AdhocTaskAssignmentLog_Create_DoesSave()
+    {
+        var task = await CreateAdhocTask();
+
+        var log = new AdhocTaskAssignmentLog
+        {
+            AdhocTaskId = task.Id,
+            ChangedByWorkerId = 5,
+            FromWorkerIdsJson = "[]",
+            ToWorkerIdsJson = "[3,7]",
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await log.Create(DbContext);
+
+        var list = DbContext.AdhocTaskAssignmentLogs.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskAssignmentLogVersions.AsNoTracking().ToList();
+
+        Assert.That(list.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(1));
+        Assert.That(list[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(list[0].ChangedByWorkerId, Is.EqualTo(5));
+        Assert.That(list[0].FromWorkerIdsJson, Is.EqualTo("[]"));
+        Assert.That(list[0].ToWorkerIdsJson, Is.EqualTo("[3,7]"));
+
+        Assert.That(versionList[0].AdhocTaskAssignmentLogId, Is.EqualTo(log.Id));
+        Assert.That(versionList[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(versionList[0].ChangedByWorkerId, Is.EqualTo(5));
+        Assert.That(versionList[0].FromWorkerIdsJson, Is.EqualTo("[]"));
+        Assert.That(versionList[0].ToWorkerIdsJson, Is.EqualTo("[3,7]"));
+    }
+
+    [Test]
+    public async Task AdhocTaskAssignmentLog_Update_DoesUpdate()
+    {
+        var task = await CreateAdhocTask();
+
+        var log = new AdhocTaskAssignmentLog
+        {
+            AdhocTaskId = task.Id,
+            ChangedByWorkerId = 5,
+            FromWorkerIdsJson = "[]",
+            ToWorkerIdsJson = "[3]",
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await log.Create(DbContext);
+        var old = DbContext.AdhocTaskAssignmentLogs.AsNoTracking().First();
+
+        log.ChangedByWorkerId = 6;
+        log.FromWorkerIdsJson = "[3]";
+        log.ToWorkerIdsJson = "[3,7]";
+        log.UpdatedByUserId = 2;
+        await log.Update(DbContext);
+
+        var list = DbContext.AdhocTaskAssignmentLogs.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskAssignmentLogVersions.AsNoTracking().ToList();
+
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(list[0].ChangedByWorkerId, Is.EqualTo(6));
+        Assert.That(list[0].FromWorkerIdsJson, Is.EqualTo("[3]"));
+        Assert.That(list[0].ToWorkerIdsJson, Is.EqualTo("[3,7]"));
+
+        Assert.That(versionList[0].ChangedByWorkerId, Is.EqualTo(old.ChangedByWorkerId));
+        Assert.That(versionList[0].FromWorkerIdsJson, Is.EqualTo(old.FromWorkerIdsJson));
+        Assert.That(versionList[0].ToWorkerIdsJson, Is.EqualTo(old.ToWorkerIdsJson));
+        Assert.That(versionList[1].ChangedByWorkerId, Is.EqualTo(6));
+        Assert.That(versionList[1].FromWorkerIdsJson, Is.EqualTo("[3]"));
+        Assert.That(versionList[1].ToWorkerIdsJson, Is.EqualTo("[3,7]"));
+    }
+
+    [Test]
+    public async Task AdhocTaskAssignmentLog_Delete_DoesDelete()
+    {
+        var task = await CreateAdhocTask();
+
+        var log = new AdhocTaskAssignmentLog
+        {
+            AdhocTaskId = task.Id,
+            ChangedByWorkerId = 5,
+            FromWorkerIdsJson = "[]",
+            ToWorkerIdsJson = "[3]",
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await log.Create(DbContext);
+
+        await log.Delete(DbContext);
+
+        var list = DbContext.AdhocTaskAssignmentLogs.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskAssignmentLogVersions.AsNoTracking().ToList();
+
+        Assert.That(list[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(versionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
+    #endregion
+
+    #region AdhocTaskComment
+
+    [Test]
+    public async Task AdhocTaskComment_Create_DoesSave()
+    {
+        var task = await CreateAdhocTask();
+
+        var comment = new AdhocTaskComment
+        {
+            AdhocTaskId = task.Id,
+            AuthorWorkerId = 9,
+            Text = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await comment.Create(DbContext);
+
+        var list = DbContext.AdhocTaskComments.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskCommentVersions.AsNoTracking().ToList();
+
+        Assert.That(list.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(1));
+        Assert.That(list[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(list[0].AuthorWorkerId, Is.EqualTo(9));
+        Assert.That(list[0].Text, Is.EqualTo(comment.Text));
+
+        Assert.That(versionList[0].AdhocTaskCommentId, Is.EqualTo(comment.Id));
+        Assert.That(versionList[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(versionList[0].AuthorWorkerId, Is.EqualTo(9));
+        Assert.That(versionList[0].Text, Is.EqualTo(comment.Text));
+    }
+
+    [Test]
+    public async Task AdhocTaskComment_Update_DoesUpdate()
+    {
+        var task = await CreateAdhocTask();
+
+        var comment = new AdhocTaskComment
+        {
+            AdhocTaskId = task.Id,
+            AuthorWorkerId = 9,
+            Text = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await comment.Create(DbContext);
+        var old = DbContext.AdhocTaskComments.AsNoTracking().First();
+
+        comment.Text = GetRandomStr();
+        comment.UpdatedByUserId = 2;
+        await comment.Update(DbContext);
+
+        var list = DbContext.AdhocTaskComments.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskCommentVersions.AsNoTracking().ToList();
+
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(list[0].Text, Is.EqualTo(comment.Text));
+        Assert.That(versionList[0].Text, Is.EqualTo(old.Text));
+        Assert.That(versionList[1].Text, Is.EqualTo(comment.Text));
+        Assert.That(versionList[1].AuthorWorkerId, Is.EqualTo(9));
+    }
+
+    [Test]
+    public async Task AdhocTaskComment_Delete_DoesDelete()
+    {
+        var task = await CreateAdhocTask();
+
+        var comment = new AdhocTaskComment
+        {
+            AdhocTaskId = task.Id,
+            AuthorWorkerId = 9,
+            Text = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await comment.Create(DbContext);
+
+        await comment.Delete(DbContext);
+
+        var list = DbContext.AdhocTaskComments.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskCommentVersions.AsNoTracking().ToList();
+
+        Assert.That(list[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(versionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
+    #endregion
+
+    #region AdhocTaskPhoto
+
+    [Test]
+    public async Task AdhocTaskPhoto_Create_DoesSave()
+    {
+        var task = await CreateAdhocTask();
+
+        var photo = new AdhocTaskPhoto
+        {
+            AdhocTaskId = task.Id,
+            UploadedDataId = 123,
+            ContentType = "image/jpeg",
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await photo.Create(DbContext);
+
+        var list = DbContext.AdhocTaskPhotos.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskPhotoVersions.AsNoTracking().ToList();
+
+        Assert.That(list.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(1));
+        Assert.That(list[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(list[0].UploadedDataId, Is.EqualTo(123));
+        Assert.That(list[0].ContentType, Is.EqualTo("image/jpeg"));
+
+        Assert.That(versionList[0].AdhocTaskPhotoId, Is.EqualTo(photo.Id));
+        Assert.That(versionList[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(versionList[0].UploadedDataId, Is.EqualTo(123));
+        Assert.That(versionList[0].ContentType, Is.EqualTo("image/jpeg"));
+    }
+
+    [Test]
+    public async Task AdhocTaskPhoto_Update_DoesUpdate()
+    {
+        var task = await CreateAdhocTask();
+
+        var photo = new AdhocTaskPhoto
+        {
+            AdhocTaskId = task.Id,
+            UploadedDataId = 123,
+            ContentType = "image/jpeg",
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await photo.Create(DbContext);
+        var old = DbContext.AdhocTaskPhotos.AsNoTracking().First();
+
+        photo.UploadedDataId = 456;
+        photo.ContentType = "image/png";
+        photo.UpdatedByUserId = 2;
+        await photo.Update(DbContext);
+
+        var list = DbContext.AdhocTaskPhotos.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskPhotoVersions.AsNoTracking().ToList();
+
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(list[0].UploadedDataId, Is.EqualTo(456));
+        Assert.That(list[0].ContentType, Is.EqualTo("image/png"));
+        Assert.That(versionList[0].UploadedDataId, Is.EqualTo(old.UploadedDataId));
+        Assert.That(versionList[0].ContentType, Is.EqualTo(old.ContentType));
+        Assert.That(versionList[1].UploadedDataId, Is.EqualTo(456));
+        Assert.That(versionList[1].ContentType, Is.EqualTo("image/png"));
+    }
+
+    [Test]
+    public async Task AdhocTaskPhoto_Delete_DoesDelete()
+    {
+        var task = await CreateAdhocTask();
+
+        var photo = new AdhocTaskPhoto
+        {
+            AdhocTaskId = task.Id,
+            UploadedDataId = 123,
+            ContentType = "image/jpeg",
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await photo.Create(DbContext);
+
+        await photo.Delete(DbContext);
+
+        var list = DbContext.AdhocTaskPhotos.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskPhotoVersions.AsNoTracking().ToList();
+
+        Assert.That(list[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(versionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
+    #endregion
+
+    #region AdhocTaskTag
+
+    [Test]
+    public async Task AdhocTaskTag_Create_DoesSave()
+    {
+        var task = await CreateAdhocTask();
+        var tag = await CreateAdhocTag();
+
+        var taskTag = new AdhocTaskTag
+        {
+            AdhocTaskId = task.Id,
+            AdhocTagId = tag.Id,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await taskTag.Create(DbContext);
+
+        var list = DbContext.AdhocTaskTags.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskTagVersions.AsNoTracking().ToList();
+
+        Assert.That(list.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(1));
+        Assert.That(list[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(list[0].AdhocTagId, Is.EqualTo(tag.Id));
+
+        Assert.That(versionList[0].AdhocTaskTagId, Is.EqualTo(taskTag.Id));
+        Assert.That(versionList[0].AdhocTaskId, Is.EqualTo(task.Id));
+        Assert.That(versionList[0].AdhocTagId, Is.EqualTo(tag.Id));
+    }
+
+    [Test]
+    public async Task AdhocTaskTag_Update_DoesUpdate()
+    {
+        var task = await CreateAdhocTask();
+        var tagOne = await CreateAdhocTag();
+        var tagTwo = await CreateAdhocTag();
+
+        var taskTag = new AdhocTaskTag
+        {
+            AdhocTaskId = task.Id,
+            AdhocTagId = tagOne.Id,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await taskTag.Create(DbContext);
+        var old = DbContext.AdhocTaskTags.AsNoTracking().First();
+
+        taskTag.AdhocTagId = tagTwo.Id;
+        taskTag.UpdatedByUserId = 2;
+        await taskTag.Update(DbContext);
+
+        var list = DbContext.AdhocTaskTags.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskTagVersions.AsNoTracking().ToList();
+
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(list[0].AdhocTagId, Is.EqualTo(tagTwo.Id));
+        Assert.That(versionList[0].AdhocTagId, Is.EqualTo(old.AdhocTagId));
+        Assert.That(versionList[1].AdhocTagId, Is.EqualTo(tagTwo.Id));
+    }
+
+    [Test]
+    public async Task AdhocTaskTag_Delete_DoesDelete()
+    {
+        var task = await CreateAdhocTask();
+        var tag = await CreateAdhocTag();
+
+        var taskTag = new AdhocTaskTag
+        {
+            AdhocTaskId = task.Id,
+            AdhocTagId = tag.Id,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await taskTag.Create(DbContext);
+
+        await taskTag.Delete(DbContext);
+
+        var list = DbContext.AdhocTaskTags.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskTagVersions.AsNoTracking().ToList();
+
+        Assert.That(list[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(versionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
+    #endregion
+}

--- a/Microting.EformBackendConfigurationBase.Tests/AdhocTaskEntityUTest.cs
+++ b/Microting.EformBackendConfigurationBase.Tests/AdhocTaskEntityUTest.cs
@@ -1,0 +1,334 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using eForm.Infrastructure.Constants;
+using Infrastructure.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+[TestFixture]
+public class AdhocTaskEntityUTest : DbTestFixture
+{
+    private static string GetRandomStr() => Guid.NewGuid().ToString();
+
+    private async Task<Property> CreateProperty()
+    {
+        var property = new Property
+        {
+            Address = GetRandomStr(),
+            CHR = GetRandomStr(),
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await property.Create(DbContext);
+
+        return property;
+    }
+
+    private async Task<AdhocArea> CreateArea(int propertyId)
+    {
+        var adhocArea = new AdhocArea
+        {
+            PropertyId = propertyId,
+            Name = GetRandomStr(),
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await adhocArea.Create(DbContext);
+
+        return adhocArea;
+    }
+
+    // Fully populated, so both the Create and Update tests exercise every
+    // column of AdhocTaskEntity/AdhocTaskEntityVersion - the reflection-based
+    // MapVersion snapshot silently drops any column that is missing or
+    // mistyped on the Version sibling, so every field must be asserted here.
+    private async Task<AdhocTaskEntity> CreateFullyPopulatedTask(int propertyId, int? areaId)
+    {
+        var visibleFrom = new DateTime(2026, 7, 1, 6, 0, 0, DateTimeKind.Utc);
+        var deadline = new DateTime(2026, 7, 10, 12, 0, 0, DateTimeKind.Utc);
+        var completedAt = new DateTime(2026, 7, 5, 8, 0, 0, DateTimeKind.Utc);
+        var archivedAt = new DateTime(2026, 7, 6, 9, 0, 0, DateTimeKind.Utc);
+
+        var adhocTaskEntity = new AdhocTaskEntity
+        {
+            Title = GetRandomStr(),
+            Description = GetRandomStr(),
+            Urgent = true,
+            PropertyId = propertyId,
+            AreaId = areaId,
+            VisibleFrom = visibleFrom,
+            Deadline = deadline,
+            VisibleReminder = true,
+            DeadlineReminder = true,
+            DeadlineReminderRepeat = 1,
+            VisibleReminderTimeMinutes = 360,
+            DeadlineReminderTimeMinutes = 420,
+            ExecutionRule = 1,
+            CreatedByWorkerId = 11,
+            Completed = true,
+            CompletedByWorkerId = 22,
+            CompletedAt = completedAt,
+            Archived = true,
+            ArchivedAt = archivedAt,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        await adhocTaskEntity.Create(DbContext);
+
+        return adhocTaskEntity;
+    }
+
+    private static void AssertMatchesEntity(AdhocTaskEntity expected, AdhocTaskEntity actual)
+    {
+        Assert.That(actual.Title, Is.EqualTo(expected.Title));
+        Assert.That(actual.Description, Is.EqualTo(expected.Description));
+        Assert.That(actual.Urgent, Is.EqualTo(expected.Urgent));
+        Assert.That(actual.PropertyId, Is.EqualTo(expected.PropertyId));
+        Assert.That(actual.AreaId, Is.EqualTo(expected.AreaId));
+        Assert.That(actual.VisibleFrom, Is.EqualTo(expected.VisibleFrom));
+        Assert.That(actual.Deadline, Is.EqualTo(expected.Deadline));
+        Assert.That(actual.VisibleReminder, Is.EqualTo(expected.VisibleReminder));
+        Assert.That(actual.DeadlineReminder, Is.EqualTo(expected.DeadlineReminder));
+        Assert.That(actual.DeadlineReminderRepeat, Is.EqualTo(expected.DeadlineReminderRepeat));
+        Assert.That(actual.VisibleReminderTimeMinutes, Is.EqualTo(expected.VisibleReminderTimeMinutes));
+        Assert.That(actual.DeadlineReminderTimeMinutes, Is.EqualTo(expected.DeadlineReminderTimeMinutes));
+        Assert.That(actual.ExecutionRule, Is.EqualTo(expected.ExecutionRule));
+        Assert.That(actual.CreatedByWorkerId, Is.EqualTo(expected.CreatedByWorkerId));
+        Assert.That(actual.Completed, Is.EqualTo(expected.Completed));
+        Assert.That(actual.CompletedByWorkerId, Is.EqualTo(expected.CompletedByWorkerId));
+        Assert.That(actual.CompletedAt, Is.EqualTo(expected.CompletedAt));
+        Assert.That(actual.Archived, Is.EqualTo(expected.Archived));
+        Assert.That(actual.ArchivedAt, Is.EqualTo(expected.ArchivedAt));
+    }
+
+    private static void AssertMatchesVersion(AdhocTaskEntity expected, AdhocTaskEntityVersion actual)
+    {
+        Assert.That(actual.AdhocTaskEntityId, Is.EqualTo(expected.Id));
+        Assert.That(actual.Title, Is.EqualTo(expected.Title));
+        Assert.That(actual.Description, Is.EqualTo(expected.Description));
+        Assert.That(actual.Urgent, Is.EqualTo(expected.Urgent));
+        Assert.That(actual.PropertyId, Is.EqualTo(expected.PropertyId));
+        Assert.That(actual.AreaId, Is.EqualTo(expected.AreaId));
+        Assert.That(actual.VisibleFrom, Is.EqualTo(expected.VisibleFrom));
+        Assert.That(actual.Deadline, Is.EqualTo(expected.Deadline));
+        Assert.That(actual.VisibleReminder, Is.EqualTo(expected.VisibleReminder));
+        Assert.That(actual.DeadlineReminder, Is.EqualTo(expected.DeadlineReminder));
+        Assert.That(actual.DeadlineReminderRepeat, Is.EqualTo(expected.DeadlineReminderRepeat));
+        Assert.That(actual.VisibleReminderTimeMinutes, Is.EqualTo(expected.VisibleReminderTimeMinutes));
+        Assert.That(actual.DeadlineReminderTimeMinutes, Is.EqualTo(expected.DeadlineReminderTimeMinutes));
+        Assert.That(actual.ExecutionRule, Is.EqualTo(expected.ExecutionRule));
+        Assert.That(actual.CreatedByWorkerId, Is.EqualTo(expected.CreatedByWorkerId));
+        Assert.That(actual.Completed, Is.EqualTo(expected.Completed));
+        Assert.That(actual.CompletedByWorkerId, Is.EqualTo(expected.CompletedByWorkerId));
+        Assert.That(actual.CompletedAt, Is.EqualTo(expected.CompletedAt));
+        Assert.That(actual.Archived, Is.EqualTo(expected.Archived));
+        Assert.That(actual.ArchivedAt, Is.EqualTo(expected.ArchivedAt));
+    }
+
+    [Test]
+    public async Task AdhocTaskEntity_Create_DoesSave()
+    {
+        // Arrange
+        var property = await CreateProperty();
+        var area = await CreateArea(property.Id);
+
+        // Act
+        var adhocTaskEntity = await CreateFullyPopulatedTask(property.Id, area.Id);
+
+        var taskList = DbContext.AdhocTasks.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(taskList.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(1));
+        Assert.That(taskList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(taskList[0].Version, Is.EqualTo(1));
+        AssertMatchesEntity(adhocTaskEntity, taskList[0]);
+
+        Assert.That(versionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(versionList[0].Version, Is.EqualTo(1));
+        AssertMatchesVersion(adhocTaskEntity, versionList[0]);
+    }
+
+    [Test]
+    public async Task AdhocTaskEntity_Create_DoesSave_NullableFieldsNull()
+    {
+        // Arrange
+        var property = await CreateProperty();
+
+        var adhocTaskEntity = new AdhocTaskEntity
+        {
+            Title = GetRandomStr(),
+            Description = GetRandomStr(),
+            Urgent = false,
+            PropertyId = property.Id,
+            AreaId = null,
+            VisibleFrom = null,
+            Deadline = null,
+            VisibleReminder = false,
+            DeadlineReminder = false,
+            DeadlineReminderRepeat = 0,
+            ExecutionRule = 0,
+            CreatedByWorkerId = 5,
+            Completed = false,
+            CompletedByWorkerId = null,
+            CompletedAt = null,
+            Archived = false,
+            ArchivedAt = null,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+
+        // Act
+        await adhocTaskEntity.Create(DbContext);
+
+        var taskList = DbContext.AdhocTasks.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(taskList[0].AreaId, Is.Null);
+        Assert.That(taskList[0].CompletedByWorkerId, Is.Null);
+        Assert.That(taskList[0].VisibleReminderTimeMinutes, Is.EqualTo(480));
+        Assert.That(taskList[0].DeadlineReminderTimeMinutes, Is.EqualTo(480));
+
+        Assert.That(versionList[0].AreaId, Is.Null);
+        Assert.That(versionList[0].CompletedByWorkerId, Is.Null);
+        Assert.That(versionList[0].VisibleReminderTimeMinutes, Is.EqualTo(480));
+        Assert.That(versionList[0].DeadlineReminderTimeMinutes, Is.EqualTo(480));
+    }
+
+    [Test]
+    public async Task AdhocTaskEntity_Update_DoesUpdate_EveryColumnSurvivesVersionSnapshot()
+    {
+        // Arrange
+        var propertyOne = await CreateProperty();
+        var propertyTwo = await CreateProperty();
+        var areaOne = await CreateArea(propertyOne.Id);
+        var areaTwo = await CreateArea(propertyTwo.Id);
+
+        var adhocTaskEntity = await CreateFullyPopulatedTask(propertyOne.Id, areaOne.Id);
+        var beforeUpdate = DbContext.AdhocTasks.AsNoTracking().First();
+
+        // Act - flip every single column to a new value
+        adhocTaskEntity.Title = GetRandomStr();
+        adhocTaskEntity.Description = GetRandomStr();
+        adhocTaskEntity.Urgent = false;
+        adhocTaskEntity.PropertyId = propertyTwo.Id;
+        adhocTaskEntity.AreaId = areaTwo.Id;
+        adhocTaskEntity.VisibleFrom = new DateTime(2026, 8, 1, 6, 0, 0, DateTimeKind.Utc);
+        adhocTaskEntity.Deadline = new DateTime(2026, 8, 10, 12, 0, 0, DateTimeKind.Utc);
+        adhocTaskEntity.VisibleReminder = false;
+        adhocTaskEntity.DeadlineReminder = false;
+        adhocTaskEntity.DeadlineReminderRepeat = 0;
+        adhocTaskEntity.VisibleReminderTimeMinutes = 500;
+        adhocTaskEntity.DeadlineReminderTimeMinutes = 510;
+        adhocTaskEntity.ExecutionRule = 0;
+        adhocTaskEntity.CreatedByWorkerId = 33;
+        adhocTaskEntity.Completed = false;
+        adhocTaskEntity.CompletedByWorkerId = null;
+        adhocTaskEntity.CompletedAt = null;
+        adhocTaskEntity.Archived = false;
+        adhocTaskEntity.ArchivedAt = null;
+        adhocTaskEntity.UpdatedByUserId = 2;
+
+        await adhocTaskEntity.Update(DbContext);
+
+        var taskList = DbContext.AdhocTasks.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(taskList.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(taskList[0].Id, Is.EqualTo(adhocTaskEntity.Id));
+        Assert.That(taskList[0].Version, Is.EqualTo(2));
+        AssertMatchesEntity(adhocTaskEntity, taskList[0]);
+
+        // Pre-mutation snapshot preserved at the old values
+        Assert.That(versionList[0].AdhocTaskEntityId, Is.EqualTo(adhocTaskEntity.Id));
+        Assert.That(versionList[0].Version, Is.EqualTo(1));
+        Assert.That(versionList[0].Title, Is.EqualTo(beforeUpdate.Title));
+        Assert.That(versionList[0].Description, Is.EqualTo(beforeUpdate.Description));
+        Assert.That(versionList[0].Urgent, Is.EqualTo(beforeUpdate.Urgent));
+        Assert.That(versionList[0].PropertyId, Is.EqualTo(beforeUpdate.PropertyId));
+        Assert.That(versionList[0].AreaId, Is.EqualTo(beforeUpdate.AreaId));
+        Assert.That(versionList[0].VisibleFrom, Is.EqualTo(beforeUpdate.VisibleFrom));
+        Assert.That(versionList[0].Deadline, Is.EqualTo(beforeUpdate.Deadline));
+        Assert.That(versionList[0].VisibleReminder, Is.EqualTo(beforeUpdate.VisibleReminder));
+        Assert.That(versionList[0].DeadlineReminder, Is.EqualTo(beforeUpdate.DeadlineReminder));
+        Assert.That(versionList[0].DeadlineReminderRepeat, Is.EqualTo(beforeUpdate.DeadlineReminderRepeat));
+        Assert.That(versionList[0].VisibleReminderTimeMinutes, Is.EqualTo(beforeUpdate.VisibleReminderTimeMinutes));
+        Assert.That(versionList[0].DeadlineReminderTimeMinutes, Is.EqualTo(beforeUpdate.DeadlineReminderTimeMinutes));
+        Assert.That(versionList[0].ExecutionRule, Is.EqualTo(beforeUpdate.ExecutionRule));
+        Assert.That(versionList[0].CreatedByWorkerId, Is.EqualTo(beforeUpdate.CreatedByWorkerId));
+        Assert.That(versionList[0].Completed, Is.EqualTo(beforeUpdate.Completed));
+        Assert.That(versionList[0].CompletedByWorkerId, Is.EqualTo(beforeUpdate.CompletedByWorkerId));
+        Assert.That(versionList[0].CompletedAt, Is.EqualTo(beforeUpdate.CompletedAt));
+        Assert.That(versionList[0].Archived, Is.EqualTo(beforeUpdate.Archived));
+        Assert.That(versionList[0].ArchivedAt, Is.EqualTo(beforeUpdate.ArchivedAt));
+
+        // Post-mutation snapshot matches every new value
+        Assert.That(versionList[1].AdhocTaskEntityId, Is.EqualTo(adhocTaskEntity.Id));
+        Assert.That(versionList[1].Version, Is.EqualTo(2));
+        AssertMatchesVersion(adhocTaskEntity, versionList[1]);
+    }
+
+    [Test]
+    public async Task AdhocTaskEntity_Delete_DoesDelete()
+    {
+        // Arrange
+        var property = await CreateProperty();
+        var adhocTaskEntity = await CreateFullyPopulatedTask(property.Id, null);
+
+        // Act
+        await adhocTaskEntity.Delete(DbContext);
+
+        var taskList = DbContext.AdhocTasks.AsNoTracking().ToList();
+        var versionList = DbContext.AdhocTaskVersions.AsNoTracking().ToList();
+
+        // Assert
+        Assert.That(taskList.Count, Is.EqualTo(1));
+        Assert.That(versionList.Count, Is.EqualTo(2));
+        Assert.That(taskList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(taskList[0].Id, Is.EqualTo(adhocTaskEntity.Id));
+        Assert.That(taskList[0].Version, Is.EqualTo(2));
+
+        Assert.That(versionList[0].AdhocTaskEntityId, Is.EqualTo(adhocTaskEntity.Id));
+        Assert.That(versionList[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(versionList[0].Version, Is.EqualTo(1));
+
+        Assert.That(versionList[1].AdhocTaskEntityId, Is.EqualTo(adhocTaskEntity.Id));
+        Assert.That(versionList[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(versionList[1].Version, Is.EqualTo(2));
+    }
+}

--- a/Microting.EformBackendConfigurationBase.Tests/DbTestFixture.cs
+++ b/Microting.EformBackendConfigurationBase.Tests/DbTestFixture.cs
@@ -99,7 +99,11 @@ public abstract class DbTestFixture
             "AreaProperties",
             "AreaPropertyVersions",
             "AreaRuleTranslations",
-            "AreaRuleTranslationVersions"
+            "AreaRuleTranslationVersions",
+            "AdhocAreas",
+            "AdhocAreaVersions",
+            "AdhocTags",
+            "AdhocTagVersions"
         };
 
         var firstRunNotDone = true;

--- a/Microting.EformBackendConfigurationBase.Tests/DbTestFixture.cs
+++ b/Microting.EformBackendConfigurationBase.Tests/DbTestFixture.cs
@@ -105,7 +105,17 @@ public abstract class DbTestFixture
             "AdhocTags",
             "AdhocTagVersions",
             "AdhocTasks",
-            "AdhocTaskVersions"
+            "AdhocTaskVersions",
+            "AdhocTaskAssignments",
+            "AdhocTaskAssignmentVersions",
+            "AdhocTaskAssignmentLogs",
+            "AdhocTaskAssignmentLogVersions",
+            "AdhocTaskComments",
+            "AdhocTaskCommentVersions",
+            "AdhocTaskPhotos",
+            "AdhocTaskPhotoVersions",
+            "AdhocTaskTags",
+            "AdhocTaskTagVersions"
         };
 
         var firstRunNotDone = true;

--- a/Microting.EformBackendConfigurationBase.Tests/DbTestFixture.cs
+++ b/Microting.EformBackendConfigurationBase.Tests/DbTestFixture.cs
@@ -103,7 +103,9 @@ public abstract class DbTestFixture
             "AdhocAreas",
             "AdhocAreaVersions",
             "AdhocTags",
-            "AdhocTagVersions"
+            "AdhocTagVersions",
+            "AdhocTasks",
+            "AdhocTaskVersions"
         };
 
         var firstRunNotDone = true;

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
@@ -164,6 +164,21 @@ public class BackendConfigurationPnDbContext: DbContext, IPluginDbContext
     public DbSet<AdhocTaskEntity> AdhocTasks { get; set; }
     public DbSet<AdhocTaskEntityVersion> AdhocTaskVersions { get; set; }
 
+    public DbSet<AdhocTaskAssignment> AdhocTaskAssignments { get; set; }
+    public DbSet<AdhocTaskAssignmentVersion> AdhocTaskAssignmentVersions { get; set; }
+
+    public DbSet<AdhocTaskAssignmentLog> AdhocTaskAssignmentLogs { get; set; }
+    public DbSet<AdhocTaskAssignmentLogVersion> AdhocTaskAssignmentLogVersions { get; set; }
+
+    public DbSet<AdhocTaskComment> AdhocTaskComments { get; set; }
+    public DbSet<AdhocTaskCommentVersion> AdhocTaskCommentVersions { get; set; }
+
+    public DbSet<AdhocTaskPhoto> AdhocTaskPhotos { get; set; }
+    public DbSet<AdhocTaskPhotoVersion> AdhocTaskPhotoVersions { get; set; }
+
+    public DbSet<AdhocTaskTag> AdhocTaskTags { get; set; }
+    public DbSet<AdhocTaskTagVersion> AdhocTaskTagVersions { get; set; }
+
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
@@ -156,6 +156,11 @@ public class BackendConfigurationPnDbContext: DbContext, IPluginDbContext
     public DbSet<ChemicalProductProperty> ChemicalProductProperties { get; set; }
     public DbSet<ChemicalProductPropertyVersion> ChemicalProductPropertyVersions { get; set; }
 
+    public DbSet<AdhocArea> AdhocAreas { get; set; }
+    public DbSet<AdhocAreaVersion> AdhocAreaVersions { get; set; }
+    public DbSet<AdhocTag> AdhocTags { get; set; }
+    public DbSet<AdhocTagVersion> AdhocTagVersions { get; set; }
+
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/BackendConfigurationPnDbContext.cs
@@ -161,6 +161,9 @@ public class BackendConfigurationPnDbContext: DbContext, IPluginDbContext
     public DbSet<AdhocTag> AdhocTags { get; set; }
     public DbSet<AdhocTagVersion> AdhocTagVersions { get; set; }
 
+    public DbSet<AdhocTaskEntity> AdhocTasks { get; set; }
+    public DbSet<AdhocTaskEntityVersion> AdhocTaskVersions { get; set; }
+
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocArea.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocArea.cs
@@ -1,0 +1,37 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+public class AdhocArea : PnBase
+{
+    public int PropertyId { get; set; }
+
+    [ForeignKey("PropertyId")]
+    public virtual Property Property { get; set; }
+
+    public string Name { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocAreaVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocAreaVersion.cs
@@ -1,0 +1,34 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocAreaVersion : PnBase
+{
+    public int AdhocAreaId { get; set; }
+
+    public int PropertyId { get; set; }
+
+    public string Name { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTag.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTag.cs
@@ -1,0 +1,33 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocTag : PnBase
+{
+    public string Name { get; set; }
+
+    // null = global tag; non-null = SDK site id of the owning worker (a user-created tag)
+    public int? OwnerWorkerId { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTagVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTagVersion.cs
@@ -1,0 +1,34 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocTagVersion : PnBase
+{
+    public int AdhocTagId { get; set; }
+
+    public string Name { get; set; }
+
+    public int? OwnerWorkerId { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignment.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignment.cs
@@ -1,0 +1,38 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+// WorkerId = SDK site id of the assigned worker; unassign is a soft-delete of the row.
+public class AdhocTaskAssignment : PnBase
+{
+    public int AdhocTaskId { get; set; }
+
+    [ForeignKey("AdhocTaskId")]
+    public virtual AdhocTaskEntity AdhocTask { get; set; }
+
+    public int WorkerId { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignmentLog.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignmentLog.cs
@@ -1,0 +1,43 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+// FromWorkerIdsJson/ToWorkerIdsJson store JSON int arrays (e.g. "[3,7]").
+// A row is appended whenever CreateTask/UpdateTask changes the assignment set.
+public class AdhocTaskAssignmentLog : PnBase
+{
+    public int AdhocTaskId { get; set; }
+
+    [ForeignKey("AdhocTaskId")]
+    public virtual AdhocTaskEntity AdhocTask { get; set; }
+
+    public int ChangedByWorkerId { get; set; }
+
+    public string FromWorkerIdsJson { get; set; }
+
+    public string ToWorkerIdsJson { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignmentLogVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignmentLogVersion.cs
@@ -1,0 +1,38 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocTaskAssignmentLogVersion : PnBase
+{
+    public int AdhocTaskAssignmentLogId { get; set; }
+
+    public int AdhocTaskId { get; set; }
+
+    public int ChangedByWorkerId { get; set; }
+
+    public string FromWorkerIdsJson { get; set; }
+
+    public string ToWorkerIdsJson { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignmentVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskAssignmentVersion.cs
@@ -1,0 +1,34 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocTaskAssignmentVersion : PnBase
+{
+    public int AdhocTaskAssignmentId { get; set; }
+
+    public int AdhocTaskId { get; set; }
+
+    public int WorkerId { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskComment.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskComment.cs
@@ -1,0 +1,39 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+public class AdhocTaskComment : PnBase
+{
+    public int AdhocTaskId { get; set; }
+
+    [ForeignKey("AdhocTaskId")]
+    public virtual AdhocTaskEntity AdhocTask { get; set; }
+
+    public int AuthorWorkerId { get; set; }
+
+    public string Text { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskCommentVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskCommentVersion.cs
@@ -1,0 +1,36 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocTaskCommentVersion : PnBase
+{
+    public int AdhocTaskCommentId { get; set; }
+
+    public int AdhocTaskId { get; set; }
+
+    public int AuthorWorkerId { get; set; }
+
+    public string Text { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskEntity.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskEntity.cs
@@ -1,0 +1,83 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+// Named "AdhocTaskEntity" (not "AdhocTask") to avoid a C# name collision with
+// the generated proto message "AdhocTask" in the plugin.
+public class AdhocTaskEntity : PnBase
+{
+    [StringLength(250)]
+    public string Title { get; set; }
+
+    public string Description { get; set; }
+
+    public bool Urgent { get; set; }
+
+    public int PropertyId { get; set; }
+
+    [ForeignKey("PropertyId")]
+    public virtual Property Property { get; set; }
+
+    public int? AreaId { get; set; }
+
+    [ForeignKey("AreaId")]
+    public virtual AdhocArea Area { get; set; }
+
+    public DateTime? VisibleFrom { get; set; }
+
+    public DateTime? Deadline { get; set; }
+
+    public bool VisibleReminder { get; set; }
+
+    public bool DeadlineReminder { get; set; }
+
+    // 0 = none, 1 = weekdays
+    public int DeadlineReminderRepeat { get; set; }
+
+    // Minutes from midnight
+    public int VisibleReminderTimeMinutes { get; set; } = 480;
+
+    // Minutes from midnight
+    public int DeadlineReminderTimeMinutes { get; set; } = 480;
+
+    // 0 = assignedOnly, 1 = everyone
+    public int ExecutionRule { get; set; }
+
+    public int CreatedByWorkerId { get; set; }
+
+    public bool Completed { get; set; }
+
+    public int? CompletedByWorkerId { get; set; }
+
+    public DateTime? CompletedAt { get; set; }
+
+    public bool Archived { get; set; }
+
+    public DateTime? ArchivedAt { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskEntityVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskEntityVersion.cs
@@ -1,0 +1,70 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System;
+
+public class AdhocTaskEntityVersion : PnBase
+{
+    public int AdhocTaskEntityId { get; set; }
+
+    public string Title { get; set; }
+
+    public string Description { get; set; }
+
+    public bool Urgent { get; set; }
+
+    public int PropertyId { get; set; }
+
+    public int? AreaId { get; set; }
+
+    public DateTime? VisibleFrom { get; set; }
+
+    public DateTime? Deadline { get; set; }
+
+    public bool VisibleReminder { get; set; }
+
+    public bool DeadlineReminder { get; set; }
+
+    public int DeadlineReminderRepeat { get; set; }
+
+    public int VisibleReminderTimeMinutes { get; set; } = 480;
+
+    public int DeadlineReminderTimeMinutes { get; set; } = 480;
+
+    public int ExecutionRule { get; set; }
+
+    public int CreatedByWorkerId { get; set; }
+
+    public bool Completed { get; set; }
+
+    public int? CompletedByWorkerId { get; set; }
+
+    public DateTime? CompletedAt { get; set; }
+
+    public bool Archived { get; set; }
+
+    public DateTime? ArchivedAt { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskPhoto.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskPhoto.cs
@@ -1,0 +1,41 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+// UploadedDataId points at the SDK "uploaded_data" row (S3-backed), following
+// the EventsGrpcService.UploadPhoto pattern.
+public class AdhocTaskPhoto : PnBase
+{
+    public int AdhocTaskId { get; set; }
+
+    [ForeignKey("AdhocTaskId")]
+    public virtual AdhocTaskEntity AdhocTask { get; set; }
+
+    public int UploadedDataId { get; set; }
+
+    public string ContentType { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskPhotoVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskPhotoVersion.cs
@@ -1,0 +1,36 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocTaskPhotoVersion : PnBase
+{
+    public int AdhocTaskPhotoId { get; set; }
+
+    public int AdhocTaskId { get; set; }
+
+    public int UploadedDataId { get; set; }
+
+    public string ContentType { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskTag.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskTag.cs
@@ -1,0 +1,41 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+// Join row for AdhocTask <-> AdhocTag (tagIds[] on the Dart AdhocTask).
+public class AdhocTaskTag : PnBase
+{
+    public int AdhocTaskId { get; set; }
+
+    [ForeignKey("AdhocTaskId")]
+    public virtual AdhocTaskEntity AdhocTask { get; set; }
+
+    public int AdhocTagId { get; set; }
+
+    [ForeignKey("AdhocTagId")]
+    public virtual AdhocTag AdhocTag { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskTagVersion.cs
+++ b/Microting.EformBackendConfigurationBase/Infrastructure/Data/Entities/AdhocTaskTagVersion.cs
@@ -1,0 +1,34 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+public class AdhocTaskTagVersion : PnBase
+{
+    public int AdhocTaskTagId { get; set; }
+
+    public int AdhocTaskId { get; set; }
+
+    public int AdhocTagId { get; set; }
+}

--- a/Microting.EformBackendConfigurationBase/Migrations/20260721154219_AddAdhocTasks.Designer.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260721154219_AddAdhocTasks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 namespace Microting.EformBackendConfigurationBase.Migrations
 {
     [DbContext(typeof(BackendConfigurationPnDbContext))]
-    partial class BackendConfigurationPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721154219_AddAdhocTasks")]
+    partial class AddAdhocTasks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.EformBackendConfigurationBase/Migrations/20260721154219_AddAdhocTasks.cs
+++ b/Microting.EformBackendConfigurationBase/Migrations/20260721154219_AddAdhocTasks.cs
@@ -1,0 +1,584 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.EformBackendConfigurationBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAdhocTasks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AdhocAreas",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    PropertyId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocAreas", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdhocAreas_Properties_PropertyId",
+                        column: x => x.PropertyId,
+                        principalTable: "Properties",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocAreaVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocAreaId = table.Column<int>(type: "int", nullable: false),
+                    PropertyId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocAreaVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTags",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Name = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    OwnerWorkerId = table.Column<int>(type: "int", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTags", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTagVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTagId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    OwnerWorkerId = table.Column<int>(type: "int", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTagVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskAssignmentLogVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskAssignmentLogId = table.Column<int>(type: "int", nullable: false),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    ChangedByWorkerId = table.Column<int>(type: "int", nullable: false),
+                    FromWorkerIdsJson = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ToWorkerIdsJson = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskAssignmentLogVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskAssignmentVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskAssignmentId = table.Column<int>(type: "int", nullable: false),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    WorkerId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskAssignmentVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskCommentVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskCommentId = table.Column<int>(type: "int", nullable: false),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    AuthorWorkerId = table.Column<int>(type: "int", nullable: false),
+                    Text = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskCommentVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskPhotoVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskPhotoId = table.Column<int>(type: "int", nullable: false),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    UploadedDataId = table.Column<int>(type: "int", nullable: false),
+                    ContentType = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskPhotoVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskTagVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskTagId = table.Column<int>(type: "int", nullable: false),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    AdhocTagId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskTagVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskVersions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskEntityId = table.Column<int>(type: "int", nullable: false),
+                    Title = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Description = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Urgent = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    PropertyId = table.Column<int>(type: "int", nullable: false),
+                    AreaId = table.Column<int>(type: "int", nullable: true),
+                    VisibleFrom = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Deadline = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    VisibleReminder = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    DeadlineReminder = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    DeadlineReminderRepeat = table.Column<int>(type: "int", nullable: false),
+                    VisibleReminderTimeMinutes = table.Column<int>(type: "int", nullable: false),
+                    DeadlineReminderTimeMinutes = table.Column<int>(type: "int", nullable: false),
+                    ExecutionRule = table.Column<int>(type: "int", nullable: false),
+                    CreatedByWorkerId = table.Column<int>(type: "int", nullable: false),
+                    Completed = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    CompletedByWorkerId = table.Column<int>(type: "int", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Archived = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    ArchivedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskVersions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTasks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Title = table.Column<string>(type: "varchar(250)", maxLength: 250, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Description = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Urgent = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    PropertyId = table.Column<int>(type: "int", nullable: false),
+                    AreaId = table.Column<int>(type: "int", nullable: true),
+                    VisibleFrom = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Deadline = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    VisibleReminder = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    DeadlineReminder = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    DeadlineReminderRepeat = table.Column<int>(type: "int", nullable: false),
+                    VisibleReminderTimeMinutes = table.Column<int>(type: "int", nullable: false),
+                    DeadlineReminderTimeMinutes = table.Column<int>(type: "int", nullable: false),
+                    ExecutionRule = table.Column<int>(type: "int", nullable: false),
+                    CreatedByWorkerId = table.Column<int>(type: "int", nullable: false),
+                    Completed = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    CompletedByWorkerId = table.Column<int>(type: "int", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Archived = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    ArchivedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTasks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdhocTasks_AdhocAreas_AreaId",
+                        column: x => x.AreaId,
+                        principalTable: "AdhocAreas",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_AdhocTasks_Properties_PropertyId",
+                        column: x => x.PropertyId,
+                        principalTable: "Properties",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskAssignmentLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    ChangedByWorkerId = table.Column<int>(type: "int", nullable: false),
+                    FromWorkerIdsJson = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ToWorkerIdsJson = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskAssignmentLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdhocTaskAssignmentLogs_AdhocTasks_AdhocTaskId",
+                        column: x => x.AdhocTaskId,
+                        principalTable: "AdhocTasks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    WorkerId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdhocTaskAssignments_AdhocTasks_AdhocTaskId",
+                        column: x => x.AdhocTaskId,
+                        principalTable: "AdhocTasks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskComments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    AuthorWorkerId = table.Column<int>(type: "int", nullable: false),
+                    Text = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskComments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdhocTaskComments_AdhocTasks_AdhocTaskId",
+                        column: x => x.AdhocTaskId,
+                        principalTable: "AdhocTasks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskPhotos",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    UploadedDataId = table.Column<int>(type: "int", nullable: false),
+                    ContentType = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskPhotos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdhocTaskPhotos_AdhocTasks_AdhocTaskId",
+                        column: x => x.AdhocTaskId,
+                        principalTable: "AdhocTasks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AdhocTaskTags",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    AdhocTaskId = table.Column<int>(type: "int", nullable: false),
+                    AdhocTagId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    WorkflowState = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CreatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdhocTaskTags", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdhocTaskTags_AdhocTags_AdhocTagId",
+                        column: x => x.AdhocTagId,
+                        principalTable: "AdhocTags",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AdhocTaskTags_AdhocTasks_AdhocTaskId",
+                        column: x => x.AdhocTaskId,
+                        principalTable: "AdhocTasks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocAreas_PropertyId",
+                table: "AdhocAreas",
+                column: "PropertyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTaskAssignmentLogs_AdhocTaskId",
+                table: "AdhocTaskAssignmentLogs",
+                column: "AdhocTaskId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTaskAssignments_AdhocTaskId",
+                table: "AdhocTaskAssignments",
+                column: "AdhocTaskId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTaskComments_AdhocTaskId",
+                table: "AdhocTaskComments",
+                column: "AdhocTaskId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTaskPhotos_AdhocTaskId",
+                table: "AdhocTaskPhotos",
+                column: "AdhocTaskId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTasks_AreaId",
+                table: "AdhocTasks",
+                column: "AreaId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTasks_PropertyId",
+                table: "AdhocTasks",
+                column: "PropertyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTaskTags_AdhocTagId",
+                table: "AdhocTaskTags",
+                column: "AdhocTagId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdhocTaskTags_AdhocTaskId",
+                table: "AdhocTaskTags",
+                column: "AdhocTaskId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AdhocAreaVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTagVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskAssignmentLogs");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskAssignmentLogVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskAssignments");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskAssignmentVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskComments");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskCommentVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskPhotos");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskPhotoVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskTags");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskTagVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTaskVersions");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTags");
+
+            migrationBuilder.DropTable(
+                name: "AdhocTasks");
+
+            migrationBuilder.DropTable(
+                name: "AdhocAreas");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 8 new entities + 8 version siblings (AdhocArea, AdhocTag, AdhocTaskEntity, AdhocTaskAssignment, AdhocTaskAssignmentLog, AdhocTaskComment, AdhocTaskPhoto, AdhocTaskTag) following PnBase soft-delete/versioning conventions
- AddAdhocTasks migration creating 16 tables
- Draft: opened to run CI verification (local test runs are prohibited); NuGet release (10.0.46) awaits explicit approval

Spec/plan: flutter-adhoc repo docs/superpowers/plans/2026-07-21-flutter-adhoc-m3-backend-transport.md (group A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)